### PR TITLE
Update messagepack to latest on Stackage

### DIFF
--- a/stagger-haskell.cabal
+++ b/stagger-haskell.cabal
@@ -19,7 +19,7 @@ library
                        deepseq,
                        errors               >= 1.4     && < 2.1,
                        hashable             == 1.2.*,
-                       pusher-messagepack   == 0.4.*,
+                       messagepack          == 0.5.*,
                        mtl,
                        stm,
                        text,


### PR DESCRIPTION
@mdpye 

Our patch was merged and published to Hackage, so we can move away from our fork.

We need to update this in order to remove the stack reference to pusher-messagepack in megabus.